### PR TITLE
Update cvver.py to support version numbers with >3 parts

### DIFF
--- a/facemorpher/cvver.py
+++ b/facemorpher/cvver.py
@@ -7,5 +7,5 @@ def is_cv3():
   return cv2.__version__.startswith('3.')
 
 def major():
-  (major, minor, _) = cv2.__version__.split('.')
+  (major, minor) = cv2.__version__.split('.')[:2]
   return major


### PR DESCRIPTION
Fix a crash when cv2.\_\_version\_\_ has more than 3 parts (e.g. 2.4.13.2):
`File "/fakepath/face_morpher/facemorpher/cvver.py", line 10, in major
    (major, minor, _) = cv2.__version__.split('.')`
`ValueError: too many values to unpack`
