### PR TITLE
Use sorted filelist for morphing multiple images

### DIFF
--- a/facemorpher/morpher.py
+++ b/facemorpher/morpher.py
@@ -73,7 +73,7 @@ def list_imgpaths(images_folder=None, src_image=None, dest_image=None):
     yield src_image
     yield dest_image
   else:
-    for fname in os.listdir(images_folder):
+    for fname in sorted(os.listdir(images_folder)):
       if (fname.lower().endswith('.jpg') or
          fname.lower().endswith('.png') or
          fname.lower().endswith('.jpeg')):


### PR DESCRIPTION
Dear @alyssaq, I just realized that during multiple image morph, the order of files implicitly depends on the directory iterator. I switched to a sorted list for more expectable behavior. You might want consider merging. Best, Martin